### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,5 +1,7 @@
 name: Automatic Version Bump with Commitizen
 
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lalgonzales/ai-assistance-guides/security/code-scanning/1](https://github.com/lalgonzales/ai-assistance-guides/security/code-scanning/1)

To address the issue, add an explicit `permissions` key to the workflow file. Since the workflow involves pushing changes and tags, it requires `contents: write` permission. However, other permissions should be restricted to avoid unnecessary access. The `permissions` key can be added at the root of the workflow file to apply to all jobs in the workflow, or it can be added under individual jobs to scope permissions more narrowly. In this case, adding it at the root is sufficient and simplifies the configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
